### PR TITLE
Handle lines with a property name and no value.

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -154,6 +154,14 @@ func stateSeparator(s *scanner, ch rune) stateFunc {
 		return stateSeparatorChar
 	}
 
+	if ch == '\r' || ch == '\n' {
+		s.p.values[s.key.String()] = ""
+		s.key.Reset()
+		s.value.Reset()
+		s.current = &s.key
+		return stateNone
+	}
+
 	if isWhitespace(ch) {
 		return stateSeparator
 	}
@@ -167,6 +175,14 @@ func stateSeparator(s *scanner, ch rune) stateFunc {
 func stateSeparatorChar(s *scanner, ch rune) stateFunc {
 	if next := s.checkEscape(ch); next != nil {
 		return next
+	}
+
+	if ch == '\r' || ch == '\n' {
+		s.p.values[s.key.String()] = ""
+		s.key.Reset()
+		s.value.Reset()
+		s.current = &s.key
+		return stateNone
 	}
 
 	if isWhitespace(ch) {


### PR DESCRIPTION
This commit fixes a defect in the handling of lines with only a property name, and maybe a separator, but no value.  In those cases the property is considered set to an empty string.  (Prior to this change, such cases would set the property name to the contents of the next non-empty line, even if it was a comment.)